### PR TITLE
block scope for references and globals

### DIFF
--- a/test/test.ts
+++ b/test/test.ts
@@ -62,3 +62,33 @@ describe('extract_names', () => {
 		assert.deepEqual(extract_names(param), ['a', 'c', 'd']);
 	});
 });
+
+describe('extract_globals', () => {
+	it('extract globals correctly', () => {
+		const program = parse(`
+			const a = b;
+			c;
+		`);
+
+		const { globals } = analyze(program);
+		assert.equal(globals.size, 2);
+		assert.ok(globals.has('b'));
+		assert.ok(globals.has('c'));
+	});
+
+	it('understand block scope', () => {
+		const program = parse(`
+			const a = b + c;
+			let b;
+			function foo(d) {
+				const g = d + e + f;
+				let e;
+			}
+		`);
+
+		const { globals } = analyze(program);
+		assert.equal(globals.size, 2);
+		assert.ok(globals.has('f'));
+		assert.ok(globals.has('c'));
+	});
+});


### PR DESCRIPTION
Currently the globals did not follow block scope, for example the following:
```js
const a = b + c;
let b;
function foo(d) {
	const g = d + e + f;
	let e;
}
```
will get `c`, `g`, `d`, `e`, `f` as `globals`, because they are all "referenced" in the program scope, yet the program scope only have declarations for `a` and `b`.

I've change the computing global scope to computed when exiting a scope, anything referenced within the scope but not declared within the scope or parent scopes, will be considered as global.

furthermore, reference within the scope, should not be considered as reference in the parent scope.