### PR TITLE
make Scope methods the same as svelte's

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,9 +89,9 @@
       "dev": true
     },
     "estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.8.1.tgz",
+      "integrity": "sha512-H6cJORkqvrNziu0KX2hqOMAlA2CiuAxHeGJXSIoKA/KLv229Dw806J3II6mKTm5xiDX1At1EXCfsOQPB+tMB+g==",
       "dev": true
     },
     "fs.realpath": {
@@ -328,6 +328,14 @@
       "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+          "dev": true
+        }
       }
     },
     "sander": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
     "types"
   ],
   "devDependencies": {
+    "@types/estree": "0.0.39",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.9.4",
     "acorn": "^7.0.0",
+    "estree-walker": "^0.8.1",
     "mocha": "^5.2.0",
     "rollup": "^0.65.2",
     "rollup-plugin-sucrase": "^2.1.0",


### PR DESCRIPTION
make Scope having the same interface as the one in svelte's, so that can be imported from svelte.
- Moved `add_declaration` into Scope
- Added `initialised_declarations`
- Update type references