### PR TITLE
fix extracting globals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,10 +100,9 @@ export function analyze(expression) {
 
 		if (!scope.references.has(reference.name)) {
 			add_reference(scope, reference.name);
-
-			if (!scope.find_owner(reference.name)) {
-				globals.set(reference.name, reference);
-			}
+		}
+		if (!scope.find_owner(reference.name)) {
+			globals.set(reference.name, reference);
 		}
 	}
 

--- a/test/test.js
+++ b/test/test.js
@@ -141,12 +141,17 @@ describe('extract_globals', it => {
 		const program = parse(`
 			const a = b;
 			c;
+			d = 1;
+			function foo(d) {
+				return d;
+			}
 		`);
 
 		const { globals } = analyze(program);
-		assert.equal(globals.size, 2);
+		assert.equal(globals.size, 3);
 		assert.ok(globals.has('b'));
 		assert.ok(globals.has('c'));
+		assert.ok(globals.has('d'));
 	});
 
 	it('understand block scope', () => {


### PR DESCRIPTION
This breaks https://github.com/sveltejs/svelte/issues/6492

i branched out from `v2.0.3`, not sure can this be cherry-picked into both v2 and v3?

breaking change introduced by https://github.com/Rich-Harris/periscopic/commit/053c1ea2e821ecdaa38b8aa925a4ee75f9371427