### PR TITLE
Add `main` to work around `eslint-plugin-import` issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "periscopic",
   "version": "3.0.3",
   "repository": "Rich-Harris/periscopic",
+  "main": "src/index.js",
   "module": "src/index.js",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Svelte can't upgrade `periscopic` due to https://github.com/benmosher/eslint-plugin-import/issues/2132, https://github.com/benmosher/eslint-plugin-import/issues/1868, https://github.com/benmosher/eslint-plugin-import/issues/1810

Alternatively, I could either add `eslint` ignores everywhere or disable that plugin. Disabling the plugin might not be the worst idea. I'd expect TypeScript to find missing imports. But anyway, this seems easy enough and doesn't seem like a terribly bad idea since `module` isn't listed in the official `package.json` spec (https://docs.npmjs.com/cli/v7/configuring-npm/package-json)