### PR TITLE
fix exports to work with esbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "main": "src/index.js",
   "module": "src/index.js",
   "type": "module",
-  "exports": {
-    "import": "./src/index.js"
-  },
+  "exports": "./src/index.js",
   "types": "types/index.d.ts",
   "files": [
     "src",


### PR DESCRIPTION
When bundling using esbuild in remix.js, the non-standard "import" entry is not recognised. Either it should be `"exports": {"default": "..."}` or simply a string (this PR).

See Sindre Sorhus package `matcher` (also pure ESM) using this `exports` pattern: https://github.com/sindresorhus/matcher/blob/main/package.json#L14
or spec:
https://nodejs.org/api/packages.html#main-entry-point-export