### PR TITLE
types: add export to package.json, test with strict mode and node16 resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,97 +1,131 @@
 {
   "name": "periscopic",
   "version": "3.0.4",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@types/estree": {
+  "packages": {
+    "": {
+      "name": "periscopic",
+      "version": "3.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^3.0.0",
+        "is-reference": "^3.0.0"
+      },
+      "devDependencies": {
+        "@types/estree": "0.0.39",
+        "acorn": "^7.0.0",
+        "typescript": "^4.1.2",
+        "uvu": "^0.5.1"
+      }
+    },
+    "node_modules/@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
-    "acorn": {
+    "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "dequal": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
-      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
-      "dev": true
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
-    "diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "dev": true
+    "node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
-    "estree-walker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.0.tgz",
-      "integrity": "sha512-s6ceX0NFiU/vKPiKvFdR83U1Zffu7upwZsGwpoqfg5rbbq1l50WQ5hCeIvM6E6oD4shUHCYMsiFPns4Jk0YfMQ=="
+    "node_modules/estree-walker": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.2.tgz",
+      "integrity": "sha512-C03BvXCQIH/po+PNPONx/zSM9ziPr9weX8xNhYb/IJtdJ9z+L4z9VKPTB+UTHdmhnIopA2kc419ueyVyHVktwA=="
     },
-    "is-reference": {
+    "node_modules/is-reference": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.0.tgz",
       "integrity": "sha512-Eo1W3wUoHWoCoVM4GVl/a+K0IgiqE5aIo4kJABFyMum1ZORlPkC+UC357sSQUL5w5QCE5kCC9upl75b7+7CY/Q==",
-      "requires": {
-        "@types/estree": "*"
-      },
       "dependencies": {
-        "@types/estree": {
-          "version": "0.0.50",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-          "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
-        }
+        "@types/estree": "*"
       }
     },
-    "kleur": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
-      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
-      "dev": true
-    },
-    "mri": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
-      "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
-      "dev": true
-    },
-    "sade": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
-      "integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true,
-      "requires": {
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "dependencies": {
         "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
-    "totalist": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
-      "integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==",
-      "dev": true
-    },
-    "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
-      "dev": true
-    },
-    "uvu": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.1.tgz",
-      "integrity": "sha512-JGxttnOGDFs77FaZ0yMUHIzczzQ5R1IlDeNW6Wymw6gAscwMdAffVOP6TlxLIfReZyK8tahoGwWZaTCJzNFDkg==",
+    "node_modules/typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
-      "requires": {
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uvu": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+      "dev": true,
+      "dependencies": {
         "dequal": "^2.0.0",
         "diff": "^5.0.0",
         "kleur": "^4.0.3",
-        "sade": "^1.7.3",
-        "totalist": "^2.0.0"
+        "sade": "^1.7.3"
+      },
+      "bin": {
+        "uvu": "bin.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "is-reference": "^3.0.0"
       },
       "devDependencies": {
-        "acorn": "^7.0.0",
-        "typescript": "^4.1.2",
+        "acorn": "^8.0.0",
+        "typescript": "^4.9.0",
         "uvu": "^0.5.1"
       }
     },
@@ -25,9 +25,9 @@
       "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
     },
     "node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,20 @@
       "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
+        "@types/estree": "^1.0.0",
         "estree-walker": "^3.0.0",
         "is-reference": "^3.0.0"
       },
       "devDependencies": {
-        "@types/estree": "0.0.39",
         "acorn": "^7.0.0",
         "typescript": "^4.1.2",
         "uvu": "^0.5.1"
       }
     },
     "node_modules/@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -55,14 +55,17 @@
       }
     },
     "node_modules/estree-walker": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.2.tgz",
-      "integrity": "sha512-C03BvXCQIH/po+PNPONx/zSM9ziPr9weX8xNhYb/IJtdJ9z+L4z9VKPTB+UTHdmhnIopA2kc419ueyVyHVktwA=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/is-reference": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.0.tgz",
-      "integrity": "sha512-Eo1W3wUoHWoCoVM4GVl/a+K0IgiqE5aIo4kJABFyMum1ZORlPkC+UC357sSQUL5w5QCE5kCC9upl75b7+7CY/Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.1.tgz",
+      "integrity": "sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==",
       "dependencies": {
         "@types/estree": "*"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "types"
   ],
   "devDependencies": {
-    "@types/estree": "0.0.39",
     "acorn": "^7.0.0",
     "typescript": "^4.1.2",
     "uvu": "^0.5.1"
@@ -27,6 +26,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@types/estree": "^1.0.0",
     "estree-walker": "^3.0.0",
     "is-reference": "^3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "src/index.js",
   "type": "module",
   "exports": {
+    "types": "./types/index.js",
     "import": "./src/index.js"
   },
   "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "types"
   ],
   "devDependencies": {
-    "acorn": "^7.0.0",
-    "typescript": "^4.1.2",
+    "acorn": "^8.0.0",
+    "typescript": "^4.9.0",
     "uvu": "^0.5.1"
   },
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 import * as uvu from 'uvu';
 import * as assert from 'uvu/assert';
-import acorn from 'acorn';
+import * as acorn from 'acorn';
 import { analyze, extract_identifiers, extract_names } from '../src/index.js';
 import { walk } from 'estree-walker';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"compilerOptions": {
-		"allowJs": true,
 		"checkJs": true,
 		"strict": true,
 		"module": "node16",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,11 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"strict": true,
+		"module": "node16",
 		"target": "es2017",
 		"declaration": true,
 		"emitDeclarationOnly": true,
-		"moduleResolution": "node",
 		"outDir": "types"
 	},
 


### PR DESCRIPTION
~hold off on merging this for a bit, it may require a change to `is-reference` first~

updates upstream PRs have been merged.

This PR
- [x] adds type exports to _package.json_
- [x] runs typescript in strict mode
- [x] resolves modules in typescript in node16 (esm) mode
- [x] moves `@types/estree` to dependencies for typescript users
- [x] updates `@types/estree` to version 1.x
- [x] test compatibility with acorn version 8