### PR TITLE
fix: resolve Acorn warning in README example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ import { analyze } from 'periscopic';
 const ast = acorn.parse(`
 const a = b;
 console.log(a);
-`,{ ecmaVersion: 2022 });
+`, { ecmaVersion: 2022 });
 
 const { map, globals, scope } = analyze(ast);
 ```
@@ -46,7 +46,7 @@ import { extract_identifiers, extract_names } from 'periscopic';
 
 const ast = acorn.parse(`
 const { a, b: [c, d] = e } = opts;
-`,{ ecmaVersion: 2022 });
+`, { ecmaVersion: 2022 });
 
 const lhs = ast.body[0].declarations[0].id;
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ import { analyze } from 'periscopic';
 const ast = acorn.parse(`
 const a = b;
 console.log(a);
-`);
+`,{ ecmaVersion: 2022 });
 
 const { map, globals, scope } = analyze(ast);
 ```
@@ -46,7 +46,7 @@ import { extract_identifiers, extract_names } from 'periscopic';
 
 const ast = acorn.parse(`
 const { a, b: [c, d] = e } = opts;
-`);
+`,{ ecmaVersion: 2022 });
 
 const lhs = ast.body[0].declarations[0].id;
 


### PR DESCRIPTION
Warning message when executing README examples codes:

Since Acorn 8.0.0, options.ecmaVersion is required.
Defaulting to 2020, but this will stop working in the future.

Solution: Add the required new option.
